### PR TITLE
Add Travis CI builds, fix some macros

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: cpp
+sudo: false
+dist: trusty
+
+matrix:
+  include:
+    - env: CXX_COMPILER=g++-6
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test
+          packages:
+          - gcc-6
+          - g++-6
+    - env: CXX_COMPILER=clang++-3.9
+      addons:
+        apt:
+          sources:
+          - llvm-toolchain-precise-3.9
+          - ubuntu-toolchain-r-test
+          packages:
+          - clang-3.9
+
+script:
+  - export CXX="${CXX_COMPILER}"
+  - ./make.sh

--- a/Util.hpp
+++ b/Util.hpp
@@ -39,20 +39,31 @@
 
 #define OVERRIDE
 
-#ifdef WIN32
-#define ALWAYS_INLINE __forceinline
-#define NO_INLINE __declspec(noinline)
+#if defined(__GNUC__) && (__GNUC__ >= 4)
+#define ALWAYS_INLINE __attribute__((__always_inline__))
+#define NO_INLINE __attribute__((__noinline__))
+#elif defined(_MSC_VER) && (_MSC_VER >= 1200)
+#  define ALWAYS_INLINE __forceinline
+#  if _MSC_VER >= 1310
+#    define NO_INLINE __declspec(noinline)
+#  else
+#    define NO_INLINE
+#  endif
 #else
-#define ALWAYS_INLINE __attribute__((always_inline))
-#define NO_INLINE __declspec(noinline)
+#  define ALWAYS_INLINE
+#  define NO_INLINE
 #endif
 
 #define no_alias __restrict
 #define rst // no_alias
 
-// TODO: Implement these.
-#define LIKELY(x) x
-#define UNLIKELY(x) x
+#if defined(__GNUC__) && (__GNUC__ >= 3)
+#define LIKELY(x) __builtin_expect(!!(x), 1)
+#define UNLIKELY(x) __builtin_expect(!!(x), 0)
+#else
+#define LIKELY(x) !!(x)
+#define UNLIKELY(x) !!(x)
+#endif
 
 #ifdef _DEBUG
 static const bool kIsDebugBuild = true;
@@ -60,10 +71,16 @@ static const bool kIsDebugBuild = true;
 static const bool kIsDebugBuild = false;
 #endif
 
-#ifdef _MSC_VER
-#define ASSUME(x) __assume(x)
+#if defined(_MSC_VER) && (_MSC_VER >= 1310)
+#  define ASSUME(x) __assume(x)
+#elif defined(__has_builtin)
+#  if __has_builtin(__builtin_assume)
+#    define ASSUME(x) __builtin_assume(x)
+#  else
+#    define ASSUME(x)
+#  endif
 #else
-#define ASSUME(x)
+#  define ASSUME(x)
 #endif
 
 typedef uint32_t hash_t;

--- a/make.sh
+++ b/make.sh
@@ -1,1 +1,7 @@
-g++ -DNDEBUG -O3 -fomit-frame-pointer -msse2 -std=c++11 -D_FILE_OFFSET_BITS=64 -o mcm Archive.cpp Huffman.cpp MCM.cpp Memory.cpp Util.cpp Compressor.cpp File.cpp LZ.cpp Tests.cpp -lpthread
+#!/bin/sh
+
+if [ ! -n "${CXX}" ]; then
+    CXX=c++
+fi
+
+${CXX} -DNDEBUG -O3 -fomit-frame-pointer -msse2 -std=c++11 -D_FILE_OFFSET_BITS=64 -o mcm Archive.cpp Huffman.cpp MCM.cpp Memory.cpp Util.cpp Compressor.cpp File.cpp LZ.cpp Tests.cpp -lpthread


### PR DESCRIPTION
The Travis builds [don't work yet](https://travis-ci.org/nemequ/mcm).  I see the same errors here (Fedora 25); hopefully this will make such problems a bit easier for you to see (I know having Windows CI builds on AppVeyor is enormously helpful for me) and fix.

You'll have to sign up for an account on Travis (free).

I also fixed a few macros in `Util.hpp` (I was hoping they would fix all the errors, but alas it only fixed some).